### PR TITLE
Update ClearCommand class and functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,9 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
+
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
  * Clears the address book.
@@ -16,19 +19,26 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clears all persons whose tags contain any of "
             + "the specified tags and keywords (case-insensitive)\n"
             + "Parameters: /TAG KEYWORD [/MORE_TAGS MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " /class 7A";
+            + "Example: " + COMMAND_WORD + " /name John";
+
     public static final String MESSAGE_SUCCESS = "EduConnect has been cleared of specified tags!";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final PersonContainsKeywordsPredicate predicate;
 
-    public ClearCommand(NameContainsKeywordsPredicate predicate) {
+    public ClearCommand(PersonContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
+        model.updateFilteredPersonList(x -> !predicate.test(x));
+        List<Person> remainingPersons = model.getFilteredPersonList();
+
+        AddressBook newAddressBook = new AddressBook();
+        newAddressBook.setPersons(remainingPersons);
+
+        model.setAddressBook(newAddressBook);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,8 +21,6 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-
-
 /**
  * Parses user input.
  */

--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new ClearCommand object
@@ -20,7 +20,7 @@ public class ClearCommandParser implements Parser<ClearCommand> {
         String trimmedArgs = args.trim();
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new ClearCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new ClearCommand(new PersonContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Tests that a {@code Person} matches any of the keywords given.
+ */
+public class PersonContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> nameKeywords = new ArrayList<>();
+    private final List<String> phoneKeywords = new ArrayList<>();
+    private final List<String> emailKeywords = new ArrayList<>();
+    private final List<String> addressKeywords = new ArrayList<>();
+    private final List<String> tagsKeywords = new ArrayList<>();
+
+    // TODO: Missing keywords lists for subject and classes
+
+    public PersonContainsKeywordsPredicate(List<String> keywords) throws ParseException {
+        Map<Prefix, List<String>> keywordMap = new HashMap<>();
+        keywordMap.put(PREFIX_NAME, nameKeywords);
+        keywordMap.put(PREFIX_PHONE, phoneKeywords);
+        keywordMap.put(PREFIX_EMAIL, emailKeywords);
+        keywordMap.put(PREFIX_ADDRESS, addressKeywords);
+        keywordMap.put(PREFIX_TAG, tagsKeywords);
+
+        List<String> currentList = null;
+
+        for (String keyword : keywords) {
+            if (keywordMap.containsKey(new Prefix(keyword))) {
+                currentList = keywordMap.get(new Prefix(keyword));
+            } else if (currentList != null) {
+                currentList.add(keyword);
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));
+            }
+        }
+    }
+
+    @Override
+    public boolean test(Person person) {
+        boolean hasMatchingName = nameKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+
+        boolean hasMatchingPhone = phoneKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+
+        boolean hasMatchingEmail = emailKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+
+        boolean hasMatchingAddress = addressKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+
+        boolean hasMatchingTags = tagsKeywords.stream()
+                .anyMatch(keyword -> person.getTags().stream()
+                        .anyMatch(tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword)));
+
+        return hasMatchingName || hasMatchingPhone || hasMatchingEmail || hasMatchingAddress || hasMatchingTags;
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -22,15 +22,31 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Tests that a {@code Person} matches any of the keywords given.
  */
 public class PersonContainsKeywordsPredicate implements Predicate<Person> {
+    private boolean isClearAll = false;
+
+    // Identity fields
     private final List<String> nameKeywords = new ArrayList<>();
     private final List<String> phoneKeywords = new ArrayList<>();
     private final List<String> emailKeywords = new ArrayList<>();
+
+    // Data fields
     private final List<String> addressKeywords = new ArrayList<>();
     private final List<String> tagsKeywords = new ArrayList<>();
 
     // TODO: Missing keywords lists for subject and classes
 
-    public PersonContainsKeywordsPredicate(List<String> keywords) throws ParseException {
+    /**
+     * Constructs a {@code PersonContainsKeywordsPredicate}
+     *
+     * @param searchQuery A list representing the search or filter query by the user
+     * @throws ParseException If a non-empty search query was given that didn't fit the categories
+     */
+    public PersonContainsKeywordsPredicate(List<String> searchQuery) throws ParseException {
+        if (searchQuery.get(0).isEmpty()) {
+            isClearAll = true;
+            return;
+        }
+
         Map<Prefix, List<String>> keywordMap = new HashMap<>();
         keywordMap.put(PREFIX_NAME, nameKeywords);
         keywordMap.put(PREFIX_PHONE, phoneKeywords);
@@ -40,7 +56,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
 
         List<String> currentList = null;
 
-        for (String keyword : keywords) {
+        for (String keyword : searchQuery) {
             if (keywordMap.containsKey(new Prefix(keyword))) {
                 currentList = keywordMap.get(new Prefix(keyword));
             } else if (currentList != null) {
@@ -53,6 +69,10 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (isClearAll) {
+            return true;
+        }
+
         boolean hasMatchingName = nameKeywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -3,12 +3,16 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 public class ClearCommandTest {
 
@@ -21,12 +25,13 @@ public class ClearCommandTest {
     }
 
     @Test
-    public void execute_nonEmptyAddressBook_success() {
+    public void execute_nonEmptyAddressBook_success() throws ParseException {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccess(new ClearCommand(null), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ClearCommand(new PersonContainsKeywordsPredicate(Arrays.asList(""))),
+                model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -43,7 +43,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD
+                + " " + CliSyntax.PREFIX_NAME) instanceof ClearCommand);
+
+        assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -1,0 +1,90 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.testutil.PersonBuilder;
+
+public class PersonContainsKeywordsPredicateTest {
+    @Test
+    public void test_personContainsKeywords_returnsTrue() throws ParseException {
+        // Name
+        PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(Arrays
+                .asList(PREFIX_NAME.getPrefix(), "John"));
+        assertTrue(predicate.test(new PersonBuilder().withName("John Doe").build()));
+
+        // Contact
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_PHONE.getPrefix(), "12345678"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Email
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_EMAIL.getPrefix(), "alice12@example.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice12@example.com").build()));
+
+        // Address
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_ADDRESS.getPrefix(), "Test"));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("123 Test Rd").build()));
+
+        // Tags
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_TAG.getPrefix(), "test"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("test").build()));
+
+        // Multiple keywords in one category
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_NAME.getPrefix(), "John", "Adam"));
+        assertTrue(predicate.test(new PersonBuilder().withName("John").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("Adam").build()));
+
+        // Multiple categories
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_NAME.getPrefix(), "John", "Adam",
+                PREFIX_PHONE.getPrefix(), "12345678", PREFIX_EMAIL.getPrefix(), "test@example.com", "alice@nus.com"));
+        assertTrue(predicate.test(new PersonBuilder().withName("John").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("Adam").build()));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("test@example.com").build()));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice@nus.com").build()));
+        assertTrue(predicate.test(new PersonBuilder().withName("Steve").withPhone("12345678").build()));
+
+        // Empty search query
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(""));
+        assertTrue(predicate.test(new PersonBuilder().withName("John Doe").build()));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("alice12@example.com").build()));
+        assertTrue(predicate.test(new PersonBuilder().withAddress("123 Test Rd").build()));
+        assertTrue(predicate.test(new PersonBuilder().withTags("test").build()));
+        assertTrue(predicate.test(new PersonBuilder().build()));
+    }
+
+    @Test
+    public void test_personContainsKeywords_returnsFalse() throws ParseException {
+        // Name
+        PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(Arrays
+                .asList(PREFIX_NAME.getPrefix(), "John"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Jane Doe").build()));
+
+        // Contact
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_PHONE.getPrefix(), "87654321"));
+        assertFalse(predicate.test(new PersonBuilder().withPhone("12345678").build()));
+
+        // Email
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_EMAIL.getPrefix(), "alice12@example.com"));
+        assertFalse(predicate.test(new PersonBuilder().withEmail("bobby@example.com").build()));
+
+        // Address
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_ADDRESS.getPrefix(), "Test"));
+        assertFalse(predicate.test(new PersonBuilder().withAddress("123 NUS Rd").build()));
+
+        // Tags
+        predicate = new PersonContainsKeywordsPredicate(Arrays.asList(PREFIX_TAG.getPrefix(), "test"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("noMatchingTags").build()));
+    }
+}


### PR DESCRIPTION
Fixes #38 

There is currently no Predicate class for identifying Persons whose attributes may match any of the keywords or search query given.

Let's add a new Predicate class PersonContainsKeywordsPredicate which first checks the search query for what keywords to check in which attribute categories.

The Predicate's test method then checks a Person if any of their attributes matches any of the specified keywords.