### PR TITLE
Alpha Bug Fix: Clear and Find throw error messages when no keywords are given for a tag

### DIFF
--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -67,13 +67,25 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
         List<String> currentList = null;
 
         for (String keyword : searchQuery) {
-            if (keywordMap.containsKey(new Prefix(keyword))) {
-                currentList = keywordMap.get(new Prefix(keyword));
+            Prefix prefix = new Prefix(keyword);
+
+            if (keywordMap.containsKey(prefix)) {
+                // If switching `currentList` without adding anything in yet
+                if (currentList != null && currentList.isEmpty()) {
+                    throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+                }
+
+                currentList = keywordMap.get(prefix);
             } else if (currentList != null) {
                 currentList.add(keyword);
             } else {
                 throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
             }
+        }
+
+        // Final check if last `currentList` is empty
+        if (currentList != null && currentList.isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
         }
 
         namePredicate = new NameContainsKeywordsPredicate(nameKeywords);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -60,16 +60,6 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() throws ParseException {
-        String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, 0);
-        PersonContainsKeywordsPredicate predicate = preparePredicate("/name");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
-    }
-
-    @Test
     public void execute_singleKeyword_singlePersonFound() throws ParseException {
         String expectedMessage = String.format(FindCommand.MESSAGE_SUCCESS, 1);
         PersonContainsKeywordsPredicate predicate = preparePredicate("/name Benson");

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -48,8 +48,8 @@ public class AddressBookParserTest {
         assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
         assertThrows(ParseException.class, () ->
                 parser.parseCommand(ClearCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_NAME));
-        assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " " +
-                CliSyntax.PREFIX_NAME + " " + CliSyntax.PREFIX_ADDRESS));
+        assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " "
+                + CliSyntax.PREFIX_NAME + " " + CliSyntax.PREFIX_ADDRESS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -48,6 +48,8 @@ public class AddressBookParserTest {
         assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
         assertThrows(ParseException.class, () ->
                 parser.parseCommand(ClearCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_NAME));
+        assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " " +
+                CliSyntax.PREFIX_NAME + " " + CliSyntax.PREFIX_ADDRESS));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -43,9 +43,11 @@ public class AddressBookParserTest {
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD
-                + " " + CliSyntax.PREFIX_NAME) instanceof ClearCommand);
+                + " " + CliSyntax.PREFIX_NAME + " Bob") instanceof ClearCommand);
 
         assertThrows(ParseException.class, () -> parser.parseCommand(ClearCommand.COMMAND_WORD + " 3"));
+        assertThrows(ParseException.class, () ->
+                parser.parseCommand(ClearCommand.COMMAND_WORD + " " + CliSyntax.PREFIX_NAME));
     }
 
     @Test
@@ -74,7 +76,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("/name", "foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " /name "
+                FindCommand.COMMAND_WORD + " "
                         + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new PersonContainsKeywordsPredicate(keywords)), command);
     }


### PR DESCRIPTION
Fixes #125, fixes #116 

The current implementation is a bit messy. A possibly cleaner fix would be to use the recommended fix in #155 