### PR TITLE
PE-D: Fix bug with editting subjects

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -52,7 +52,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GENDER, PREFIX_PHONE, PREFIX_EMAIL,
-            PREFIX_ADDRESS, PREFIX_SUBJECT, PREFIX_CLASSES, PREFIX_NEXT_OF_KIN, PREFIX_EMERGENCY_CONTACT);
+            PREFIX_ADDRESS, PREFIX_CLASSES, PREFIX_NEXT_OF_KIN, PREFIX_EMERGENCY_CONTACT);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 


### PR DESCRIPTION
Fixes #223 

Bug was due to accidentally checking for duplicate prefixes for `/subject`, preventing users from adding more than 1 subject during the `edit` command.

![image](https://github.com/user-attachments/assets/538f1a27-aaa8-4aea-81ba-a061ce4056b7)
