### PR TITLE
PE-D: Fix Sort command's case sensitivity

### DIFF
--- a/src/main/java/seedu/address/logic/parser/SortCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SortCommandParser.java
@@ -31,10 +31,11 @@ public class SortCommandParser implements Parser<SortCommand> {
         logger.info("Starting to parse sort command.");
 
         switch (trimmedArgs) {
-        case "name" -> comparator = Comparator.comparing(person -> person.getName().toString());
-        case "subject" -> comparator = Comparator.comparing(person -> person.getSubjects().toString());
+        case "name" -> comparator = Comparator.comparing(person -> person.getName().toString().toLowerCase());
+        case "subject" -> comparator = Comparator.comparing(person -> person.getSubjects().toString().toLowerCase());
         case "class" -> comparator = Comparator.comparing(person ->
-                ComparatorUtil.getPrimaryClassForSorting(Collections.singletonList(person.getClasses().toString()))
+                ComparatorUtil.getPrimaryClassForSorting(Collections.singletonList(person.getClasses().toString()
+                        .toLowerCase()))
         );
         case "attendance" -> comparator = Comparator.comparing(
                 Person::getDaysAttended,


### PR DESCRIPTION
Fixes #251 

According to the specifications of feature freeze, particularly Q7, since we previously mentioned that `sort` is case insensitive, we are allowed to fix it as a bug.

![image](https://github.com/user-attachments/assets/14895a22-07d2-4559-a517-870d9f46cff5)
